### PR TITLE
docs: CI注意事項をドキュメントに追加

### DIFF
--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -364,6 +364,35 @@ docker-compose logs -f backend   # ログ確認
 
 ---
 
+## CI/CD 注意事項
+
+### コミット前チェック
+
+- `docs/PLANNING.md` がステージングされていないとコミットがブロックされる（pre-commit hook）
+- 内容変更がなくても `git add docs/PLANNING.md` が必要
+
+### E2Eテスト (Playwright)
+
+| 項目 | 注意点 |
+|------|--------|
+| APIモック | `page.route()` を使用（`frontend/e2e/fixtures.ts`）。MSWはNext.jsのrewritesをモックできない |
+| セレクタ | `button` vs `link` を正確に。複数マッチする場合は具体的な名前を指定 |
+| アクセシビリティ | `data-testid`, `aria-label`, `htmlFor`+`id`, セマンティック要素（`<aside>`, `<header>`）が必須 |
+
+### バックエンドテスト (pytest)
+
+- CIではSQLite使用（PostgreSQL不要）
+- UUID/JSON型は `GUID`, `PortableJSON` TypeDecoratorで互換性確保
+- 参照: `backend/src/agent_platform/db/types.py`
+
+### Lint
+
+- Backend: `uv run ruff check` - I001(import順), F401(未使用import), N815(変数名) など
+- Frontend: `npm run lint` - react-hooks/rules-of-hooks, exhaustive-deps など
+- 警告は許容、エラーはブロック
+
+---
+
 ## 参考リンク
 
 - [Google A2A Protocol](https://github.com/google-a2a/A2A)


### PR DESCRIPTION
## Summary

- CI注意事項を`CLAUDE.md`と`docs/PLANNING.md`に追加
- コミット前チェック、E2Eテスト、バックエンドテストのベストプラクティスを文書化

## Changes

### CLAUDE.md
- CI Notesセクションを追加
- コミット前のPLANNING.md必須要件
- E2Eテストの`page.route()`によるAPIモック
- バックエンドのSQLite互換性

### docs/PLANNING.md
- CI/CD注意事項セクションを追加
- テーブル形式で要点を整理

## Test plan

- [x] CIは直近のPRで全てパス（25テスト成功）
- [x] ドキュメント変更のみのため、機能への影響なし