### PR TITLE
docs: 著作権年更新リマインダーをCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,3 +220,20 @@ The project has MCP servers configured in `.mcp.json`:
 cd frontend
 npm run test:e2e:headed  # Watch tests run in browser
 ```
+
+## Maintenance Reminders
+
+### Copyright Year Update (著作権年更新)
+When making updates in a new calendar year, update the copyright year in the following files:
+
+**Current format**: `Copyright (c) 2024-2025`
+- `2024` = First published year (固定)
+- `2025` = Last updated year (更新時に変更)
+
+**Files to update**:
+1. `LICENSE` - Line 5 and lines 253-255
+2. `COPYRIGHT` - Line 5 and source file header templates
+3. `README.md` - License section
+4. `docs/PLANNING.md` - License section
+
+**Example**: In 2026, change `2024-2025` → `2024-2026`

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -1,5 +1,7 @@
 # AI Agent Demo Project - 実装プラン
 
+> Last reviewed: 2025-12-03
+
 ## 概要
 
 マルチユーザー対応のPersonal AI Agent SaaSプラットフォーム。


### PR DESCRIPTION
## Summary
- CLAUDE.mdにMaintenance Remindersセクションを追加
- 新しい年に更新作業を行う際の著作権年更新手順を記載

## Changes
- `CLAUDE.md`: Copyright Year Update リマインダー追加
- `docs/PLANNING.md`: Last reviewed 日付追加

## 対象ファイル（著作権年更新時）
1. LICENSE
2. COPYRIGHT  
3. README.md
4. docs/PLANNING.md